### PR TITLE
Update docs to v2.6.0

### DIFF
--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -1,6 +1,4 @@
 ### [Click here for the full API documentation](https://shaid.smartdevicelink.com/docs)
-
-SHAID v2.6.0+ now supports issue tracking and facilitating OEM communication with App Developers. Click [here](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0218-developer-oem-communication.md) for the full proposal.
 # SHAID v2.6.0
 
 Base URL: https://shaid.smartdevicelink.com/api/v2

--- a/docs/v2/index.md
+++ b/docs/v2/index.md
@@ -1,5 +1,7 @@
 ### [Click here for the full API documentation](https://shaid.smartdevicelink.com/docs)
-# SHAID v2.5.0
+
+SHAID v2.6.0+ now supports issue tracking and facilitating OEM communication with App Developers. Click [here](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0218-developer-oem-communication.md) for the full proposal.
+# SHAID v2.6.0
 
 Base URL: https://shaid.smartdevicelink.com/api/v2
 
@@ -48,7 +50,7 @@ Retrieve one or more SDL applications and metadata about them: their UUID (a uni
 | query | is_in_catalog               | boolean                                                                                                                                                                                             | false    | Whether the app should appear in the App Catalog on smartdevicelink.com.                                                                                                                                                                                                                                                    |                    |
 | query | is_homepage_app             | boolean                                                                                                                                                                                             | false    | Whether the app is eligible appear on the homepage smartdevicelink.com.                                                                                                                                                                                                                                                     |                    |
 | query | is_oem_specific             | boolean                                                                                                                                                                                             | false    | Whether the app should appear in the OEM-specific section of the App Catalog.                                                                                                                                                                                                                                               |                    |
-| query | limit                       | integer                                                                                                                                                                                             | false    | The maximum number of results to return. Max 50. Default 50.                                                                                                                                                                                                                                                                | `50`               |
+| query | limit                       | integer                                                                                                                                                                                             | false    | The maximum number of results to return. Default 50.                                                                                                                                                                                                                                                                        | `50`               |
 | query | offset                      | integer                                                                                                                                                                                             | false    | The number of results to offset, for basic pagination.                                                                                                                                                                                                                                                                      | `0`                |
 | query | sort_by                     | string: application.id, application.name, application.platform, application.status, application.approval_status, vendor.name, application.champion_approval_status, application.champion_updated_ts | false    | Which property to sort the results by.                                                                                                                                                                                                                                                                                      | `"application.id"` |
 | query | sort_order                  | string: ASC, DESC                                                                                                                                                                                   | false    | How to order the results (in combination with `sort_by`).                                                                                                                                                                                                                                                                   | `"ASC"`            |
@@ -127,6 +129,8 @@ Internal server error.
 **Schema**
 
 N/A
+
+
 
 
 


### PR DESCRIPTION
Update SHAID docs to v2.6.0 and include a reference to issue tracking and oem communication as well as a fix where the limit was incorrectly labeled as having a max of 50.